### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=279712

### DIFF
--- a/clipboard-apis/clipboard-item.https.html
+++ b/clipboard-apis/clipboard-item.https.html
@@ -102,6 +102,7 @@ promise_test(async () => {
   ['text/html',  true],
   ['image/png',  true],
   // optional data types
+  ['text/uri-list', true],
   ['image/svg+xml', true],
   ['web foo/bar',   true],
   ['web text/html', true],


### PR DESCRIPTION
In accordance to https://w3c.github.io/clipboard-apis/#dom-clipboarditem-supports
